### PR TITLE
Ignore attributes that are updated by lambda-deployer

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -159,6 +159,10 @@ resource "aws_lambda_function" "this" {
     aws_iam_role_policy_attachment.vpc,
     aws_iam_role_policy_attachment.tracing,
   ]
+
+  lifecycle {
+    ignore_changes = var.ignore_changes
+  }
 }
 
 resource "aws_lambda_layer_version" "this" {

--- a/main.tf
+++ b/main.tf
@@ -161,7 +161,13 @@ resource "aws_lambda_function" "this" {
   ]
 
   lifecycle {
-    ignore_changes = var.ignore_changes
+    ignore_changes = var.ignore_changes ? [
+      layers,
+      description,
+      memory_size,
+      timeout,
+      environment,
+    ] : []
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -161,13 +161,13 @@ resource "aws_lambda_function" "this" {
   ]
 
   lifecycle {
-    ignore_changes = var.ignore_changes ? [
+    ignore_changes = [
       layers,
       description,
       memory_size,
       timeout,
       environment,
-    ] : []
+    ]
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -167,6 +167,7 @@ resource "aws_lambda_function" "this" {
       memory_size,
       timeout,
       environment,
+      snap_start,
     ]
   }
 }

--- a/modules/alias/main.tf
+++ b/modules/alias/main.tf
@@ -29,7 +29,7 @@ resource "aws_lambda_alias" "no_refresh" {
   }
 
   lifecycle {
-    ignore_changes = [function_version]
+    ignore_changes = [function_version, description]
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -801,9 +801,3 @@ variable "logging_log_group" {
   type        = string
   default     = null
 }
-
-variable "ignore_changes" {
-  description = "Whether to ignore changes to lambdas"
-  type        = bool
-  default     = false
-}

--- a/variables.tf
+++ b/variables.tf
@@ -801,3 +801,9 @@ variable "logging_log_group" {
   type        = string
   default     = null
 }
+
+variable "ignore_changes" {
+    description = "List of attributes to ignore changes"
+    type        = list(string)
+    default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -803,7 +803,7 @@ variable "logging_log_group" {
 }
 
 variable "ignore_changes" {
-    description = "List of attributes to ignore changes"
-    type        = list(string)
-    default     = []
+  description = "Whether to ignore changes to lambdas"
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
I forked the aws lambda module to allow us to ignore attributes that are modified by lambda-deployer